### PR TITLE
Enforce application enabled and processing_quota

### DIFF
--- a/spec/server.coffee
+++ b/spec/server.coffee
@@ -491,6 +491,8 @@ describe 'Applications in database', ->
         secret: "321321321321321"
         label: "Added via database"
         owner_email: "test@example.com"
+        processing_quota: 0
+        enabled: false
 
     before (done) ->
         applications.deleteAll(config)
@@ -519,6 +521,8 @@ describe 'Applications in database', ->
                 auth = state.server.authdb
                 chai.expect(auth, Object.keys(auth)).to.have.property addedApp.key
                 chai.expect(auth[addedApp.key].secret).to.equal addedApp.secret
+                chai.expect(auth[addedApp.key].processing_quota).to.equal addedApp.processing_quota
+                chai.expect(auth[addedApp.key].enabled).to.equal addedApp.enabled
             catch e
                 return done e
             return done()

--- a/spec/server.coffee
+++ b/spec/server.coffee
@@ -86,6 +86,16 @@ enableTestAuth = (server) ->
             secret: 'reiL1ohqu1do'
             enabled: true
             processing_quota: 1
+        'zero-processing-quota':
+            admin: false
+            secret: 'zero0zero'
+            processing_quota: 0
+            enabled: true
+        'not-enabled':
+            admin: false
+            secret: 'disabled4reasons'
+            enabled: false
+            processing_quota: 1
 
 HTTP =
     get: http.get
@@ -187,6 +197,49 @@ commonGraphTests = (type, state) ->
                 chai.expect(res.statusCode).to.equal 403
                 done()
 
+    describe 'Disabled application making processing request', ->
+        p = { height: 110, width: 133, y: 230, input: "files/grid-toastybob.jpg" }
+        u = graph_url 'crop', p, 'not-enabled', 'disabled4reasons'
+
+        it 'should fail with a 403', (done) ->
+            enableTestAuth state.server
+
+            HTTP[method] u, (res) ->
+                chai.expect(res.statusCode).to.equal 403
+                done()
+
+    describe 'Disabled application making cache request', ->
+        p = { height: 110, width: 133, y: 230, input: "files/grid-toastybob.jpg" }
+        u = graph_url 'crop', p, 'not-enabled', 'disabled4reasons'
+
+        it 'should fail with a 403', (done) ->
+            enableTestAuth state.server
+
+            HTTP[method] u, (res) ->
+                chai.expect(res.statusCode).to.equal 403
+                done()
+
+    describe 'Application with processing_quota=0 making cache request', ->
+        p = { height: 110, width: 133, y: 230, input: "files/grid-toastybob.jpg" }
+        u = graph_url 'crop', p, 'zero-processing-quota', 'zero0zero'
+
+        it 'should succeed with redirect to file', (done) ->
+            HTTP[method] u, (res) ->
+                chai.expect(res.statusCode).to.equal 301
+                location = res.headers['location']
+                chai.expect(location).to.contain cacheurl
+                done()
+
+    describe 'Application with processing_quota=0 making processing request', ->
+        p = { height: 110, width: 134, input: "files/grid-toastybob.jpg" }
+        u = graph_url 'crop', p, 'zero-processing-quota', 'zero0zero'
+
+        it 'should fail with a 403', (done) ->
+            enableTestAuth state.server
+
+            HTTP[method] u, (res) ->
+                chai.expect(res.statusCode).to.equal 403
+                done()
 
 describe 'Server', ->
     s = null

--- a/spec/server.coffee
+++ b/spec/server.coffee
@@ -79,9 +79,13 @@ enableTestAuth = (server) ->
         'ooShei0queigeeke':
             admin: false
             secret: 'reeva9aijo1Ooj9w'
+            enabled: true
+            processing_quota: 1
         'niem4Hoodaku':
             admin: true
             secret: 'reiL1ohqu1do'
+            enabled: true
+            processing_quota: 1
 
 HTTP =
     get: http.get

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -105,12 +105,16 @@ class Server extends EventEmitter
             @authdb[config.api_key] =
                 admin: false
                 secret: config.api_secret
+                enabled: true
+                processing_quota: 1
 
         if config.admin_key or config.admin_secret
             @authdb = {} if not @authdb
             @authdb[config.admin_key] =
                 admin: true
                 secret: config.admin_secret
+                enabled: true
+                processing_quota: 1
 
         @cache = cache.fromOptions config
         @jobManager = new jobmanager.JobManager config

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -177,6 +177,8 @@ class Server extends EventEmitter
                 @authdb[a.key] =
                     secret: a.secret
                     admin: false # TODO: support in DB?
+                    processing_quota: a.processing_quota
+                    enabled: Boolean a.enabled
         .then () =>
             return new Promise (reject, resolve) =>
                 @httpserver.listen port, (err) =>

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -249,14 +249,19 @@ class Server extends EventEmitter
     checkAuth: (req, scope) ->
         return true if not @authdb # Authentication disabled
 
-        secret = @authdb[req.apikey]?.secret
-        return false if not secret
+        auth = @authdb[req.apikey]
+        return false if not auth?
+        return false if not auth.secret
+        return false if not auth.enabled
 
-        if scope == 'admin' and not @authdb[req.apikey]?.admin
-          return false
+        if scope == 'admin' and not auth.admin
+            return false
+
+        if scope == 'processing' and auth.processing_quota <= 0
+            return false
 
         hash = crypto.createHash 'md5'
-        hash.update req.graphspec+req.query+secret
+        hash.update req.graphspec+req.query+auth.secret
         expectedToken = hash.digest 'hex'
         return req.token == expectedToken
 
@@ -284,6 +289,8 @@ class Server extends EventEmitter
                 @logEvent 'graph-in-cache', { err: err, method: 'GET', request: request.url, key: req.cachekey, url: cached }
                 return @redirectToCache err, cached, response, 301
             else
+                return if not @ensureAuthenticated req, response, 'processing'
+
                 onJobCompleted = (err, job) =>
                     @logEvent 'serve-processed-file', { request: req.request, url: job.results?.url }
                     return @redirectToCache err, job.results?.url, response, 301
@@ -311,6 +318,8 @@ class Server extends EventEmitter
                 @logEvent 'graph-in-cache', { err: err, method: 'POST', request: request.url, key: req.cachekey, url: cached }
                 return @redirectToCache err, cached, response, 301
             else
+                return if not @ensureAuthenticated req, response, 'processing'
+
                 onJobCompleted = null # not waiting for result
                 # TODO: return a job URL instead of the cache URL
                 cacheurl = @cache.urlForKey?(req.cachekey) # HACK, uses internal method
@@ -321,8 +330,8 @@ class Server extends EventEmitter
                         return @redirectToCache err, cacheurl, response, 202
 
 
-    ensureAuthenticated: (req, response) ->
-        scope = if req.noCache then 'admin' else null
+    ensureAuthenticated: (req, response, scope = null) ->
+        scope = 'admin' if req.noCache
         authenticated = @checkAuth req, scope
         if not authenticated
             response.writeHead 403


### PR DESCRIPTION
Will allow to disable apps/key access in two steps:

* Setting `processing_quota=0`: Existing cached objects can still be fetched, but not cause new images to be processed
* Setting `enabled=false`: Application cannot make cache nor processing requests