### PR TITLE
server: Avoid RangeError due to err.code being 0

### DIFF
--- a/src/server.coffee
+++ b/src/server.coffee
@@ -234,7 +234,7 @@ class Server extends EventEmitter
 
     redirectToCache: (err, target, response, successCode) ->
         if err
-            if err.code?
+            if err.code
                 err.result?.code = err.code if not err.result?.code
                 response.writeHead err.code, { 'Content-Type': 'application/json' }
                 response.end JSON.stringify err.result


### PR DESCRIPTION
Seems to be new in node.js 4.6

Uncaught exception: { [RangeError: Invalid status code: 0] code: 541 }
  at ServerResponse.writeHead (_http_server.js:192:11)
  at ServerResponse.wrappedWriteHead [as writeHead] (/app/node_modules/newrelic/lib/instrumentation/core/http.js:237:24)
  at Server.redirectToCache (/app/src/server.coffee:239:26)
  at Object.onJobCompleted [as callback] (/app/src/server.coffee:296:29)
  at JobManager.onResult (/app/src/jobmanager.coffee:209:20)